### PR TITLE
Remove test for regular files in LoggerFactory

### DIFF
--- a/application/src/Service/LoggerFactory.php
+++ b/application/src/Service/LoggerFactory.php
@@ -24,8 +24,8 @@ class LoggerFactory implements FactoryInterface
         if (isset($config['logger']['log'])
             && $config['logger']['log']
             && isset($config['logger']['path'])
-            && is_file($config['logger']['path'])
             && is_writable($config['logger']['path'])
+            && is_dir($config['logger']['path'] === false)
         ) {
             $writer = new Stream($config['logger']['path']);
         } else {

--- a/application/test/OmekaTest/Service/LoggerFactoryTest.php
+++ b/application/test/OmekaTest/Service/LoggerFactoryTest.php
@@ -12,7 +12,7 @@ class LoggerFactoryTest extends TestCase
     protected $validConfig = [
         'logger' => [
             'log' => true,
-            'path' => '/',
+            'path' => '/dev/stdout',
             'priority' => Logger::NOTICE,
         ],
     ];


### PR DESCRIPTION
Allows '/dev/stdout' to be specified as the logging path, by removing the test for regular files (allowing character devices, sockets, etc.).